### PR TITLE
Pin version of markupsafe

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -4,7 +4,7 @@ module-description: Provide services to the Job Browser front end tool.
 
 service-language: python
 
-module-version: 1.1.1
+module-version: 1.1.2
 
 owners: [eapearson]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pyyaml==5.4.1
 requests==2.27.1 
 toml==0.10.2 
 black==21.12b0
+markupsafe==2.0.1


### PR DESCRIPTION
Pin version of markup safe ImportError: cannot import name 'soft_unicode' from 'markupsafe'
bump kbase.yml